### PR TITLE
Add hashdata api endpoint

### DIFF
--- a/src/server/checkface.py
+++ b/src/server/checkface.py
@@ -152,8 +152,9 @@ def image_generation(hash):
 def hashlatentdata(hash):
     os.makedirs("outputImages", exist_ok=True)
     seed = int(hashlib.sha256(hash.encode('utf-8')).hexdigest(), 16) % 10**8
-    latent = fromSeed(Gs, seed)
-    return jsonify({ "seed": seed, "qlatent": latent})
+    qlatent = fromSeed(Gs, seed)
+    dlatent = toDLat(Gs, qlatent)
+    return jsonify({ "seed": seed, "qlatent": qlatent, "dlatent": dlatent })
 
 def worker():
     dnnlib.tflib.init_tf()

--- a/src/server/checkface.py
+++ b/src/server/checkface.py
@@ -20,7 +20,7 @@ import pickle
 import numpy as np
 import queue
 import hashlib
-from flask import send_file, request
+from flask import send_file, request, jsonify
 np.set_printoptions(threshold=np.inf)
 
 import flask
@@ -147,6 +147,13 @@ def image_generation(hash):
     else:
         print(f"Image file {name} already exists")
     return send_file(name, mimetype='image/jpg')
+
+@app.route('/api/hashdata/<path:hash>', methods=['GET'])
+def hashlatentdata(hash):
+    os.makedirs("outputImages", exist_ok=True)
+    seed = int(hashlib.sha256(hash.encode('utf-8')).hexdigest(), 16) % 10**8
+    latent = fromSeed(Gs, seed)
+    return jsonify({ "seed": seed, "qlatent": latent})
 
 def worker():
     dnnlib.tflib.init_tf()


### PR DESCRIPTION
Adds an api endpoint at `/api/hashdata/{hash}` so that one can gain some insight into how hashes (or any user input) are converted to latents.