### PR TITLE
Fix encoding

### DIFF
--- a/docs/assets/js/script.js
+++ b/docs/assets/js/script.js
@@ -4,7 +4,7 @@ $(document).ready(function () {
        
         var myImage = document.getElementById("my-image");
         var value = document.getElementById('object').value;
-        myImage.src = 'https://api.checkface.ml/api/' + encodeURIComponent(value) + "?dim=500";
+        myImage.src = 'https://api.checkface.ml/api/face/?value=' + encodeURIComponent(value) + "&dim=500";
         window.history.pushState({ value: value }, 'Check Face - ' + value, '?value=' + encodeURIComponent(value));
         return false;
     }
@@ -13,7 +13,7 @@ $(document).ready(function () {
     const currentVal = (urlParams.get('value') || "");
     if(currentVal) {
         document.getElementById('object').value = currentVal;
-        document.getElementById("my-image").src = 'https://api.checkface.ml/api/' + encodeURIComponent(currentVal) + "?dim=500";
+        document.getElementById("my-image").src = 'https://api.checkface.ml/api/face/?value=' + encodeURIComponent(currentVal) + "&dim=500";
     }
 
     //Can't get chrome to automatically add search engine using osdd, so get it to do a full

--- a/src/dotnet-windows/checkface-dotnet/CheckFaceForm.cs
+++ b/src/dotnet-windows/checkface-dotnet/CheckFaceForm.cs
@@ -55,7 +55,7 @@ namespace checkface_dotnet
                 pictureBox1.Image = Properties.Resources.loader;
                 pictureBox1.SizeMode = PictureBoxSizeMode.CenterImage;
                 string enc = System.Web.HttpUtility.UrlEncode(textBox1.Text);
-                pictureBox1.LoadAsync($"https://api.checkface.ml/api/{enc}?dim=300");
+                pictureBox1.LoadAsync($"https://api.checkface.ml/api/face/?value={enc}&dim=300");
             }
         }
     }

--- a/src/electron/renderer.js
+++ b/src/electron/renderer.js
@@ -10,7 +10,7 @@ console.log("Hashdata:", hashdata);
 let img = document.querySelector("#checkfaceimg");
 let siteurl = `https://checkface.ml/`;
 if(hashdata.sum) {
-    img.src = `https://api.checkface.ml/api/${hashdata.sum}?dim=400`;
+    img.src = `https://api.checkface.ml/api/face/?value=${hashdata.sum}&dim=400`;
     siteurl += `?value=${hashdata.sum}`
 }
 else {

--- a/src/extension/content.js
+++ b/src/extension/content.js
@@ -19,7 +19,7 @@ function showPopup(hashMessage) {
 
     document.body.appendChild(div);
     div.onclick = removeFunc;
-    div.querySelector("#checkfaceimg").src = "https://api.checkface.ml/api/" + hashMessage + "?dim=300";
+    div.querySelector("#checkfaceimg").src = "https://api.checkface.ml/api/face/?value=" + hashMessage + "&dim=300";
     if(hashMessage.length > 103) {
       hashMessage = hashMessage.substring(0, 100) + "...";
     }
@@ -55,7 +55,7 @@ function addHoverFaceCheck(node) {
       </div>
     </div>
     `
-    div.querySelector("#checkfaceimg").src = "https://api.checkface.ml/api/" + hashMessage + "?dim=200";
+    div.querySelector("#checkfaceimg").src = "https://api.checkface.ml/api/face/?value=" + hashMessage + "&dim=200";
     div.querySelector("#checkfacehash").innerHTML = hashMessage.substring(0, 7);
     node.appendChild(div);
   }

--- a/src/server/checkface.py
+++ b/src/server/checkface.py
@@ -155,7 +155,7 @@ def hashlatentdata(hash):
     latent = fromSeed(seed)
     return jsonify({ "seed": seed, "qlatent": latent.tolist()})
 
-@app.route('/queue/', methods=['GET'])
+@app.route('/queue', methods=['GET'])
 def healthcheck():
     return jsonify({"queue": q.qsize()})
 

--- a/src/server/checkface.py
+++ b/src/server/checkface.py
@@ -117,7 +117,7 @@ image_dim = 300
 app = flask.Flask(__name__)
 app.config["DEBUG"] = False
 
-@app.route('/status', methods=['GET'])
+@app.route('/status/', methods=['GET'])
 def status():
     return ''
 
@@ -129,8 +129,17 @@ def home():
 q = queue.Queue()
 doneJobSeeds = { "apple", "banana", "orange" }
 
-@app.route('/api/<path:hash>', methods=['GET'])
-def image_generation(hash):
+
+@app.route('/api/<string:hash>', methods=['GET'])
+def image_generation_legacy(hash):
+    '''
+    string as a type will accept anything without a slash
+    path as a type would accept slashes as well
+
+    https://flask.palletsprojects.com/en/1.0.x/quickstart/#variable-rules
+
+    '''
+
     os.makedirs("outputImages", exist_ok=True)
     seed = int(hashlib.sha256(hash.encode('utf-8')).hexdigest(), 16) % 10**8
     requested_image = image_dim
@@ -149,13 +158,39 @@ def image_generation(hash):
         print(f"Image file {name} already exists")
     return send_file(name, mimetype='image/jpg')
 
-@app.route('/hashdata/<path:hash>', methods=['GET'])
-def hashlatentdata(hash):
+@app.route('/api/face/', methods=['GET'])
+def image_generation():
+    os.makedirs("outputImages", exist_ok=True)
+    hash = request.args.get('value')
+    if not hash:
+        hash = ''
+    seed = int(hashlib.sha256(hash.encode('utf-8')).hexdigest(), 16) % 10**8
+    requested_image = image_dim
+    try:
+        requested_image = int(request.args.get('dim')) # if key doesn't exist, returns None
+        if requested_image is None or requested_image < 10 or requested_image > 1024:
+            requested_image = image_dim
+    except:
+        requested_image = image_dim
+    name = os.path.join(os.getcwd(), "outputImages", f"s{seed}_{requested_image}.jpg")
+    if not os.path.isfile(name):
+        q.put((seed, requested_image))
+        while not ((seed, requested_image) in doneJobSeeds):
+            time.sleep(0.05)
+    else:
+        print(f"Image file {name} already exists")
+    return send_file(name, mimetype='image/jpg')
+
+@app.route('/api/hashdata/', methods=['GET'])
+def hashlatentdata():
+    hash = request.args.get('value')
+    if not hash:
+        hash = ''
     seed = int(hashlib.sha256(hash.encode('utf-8')).hexdigest(), 16) % 10**8
     latent = fromSeed(seed)
-    return jsonify({ "seed": seed, "qlatent": latent.tolist()})
+    return jsonify({"seed": seed, "qlatent": latent.tolist()})
 
-@app.route('/queue', methods=['GET'])
+@app.route('/api/queue/', methods=['GET'])
 def healthcheck():
     return jsonify({"queue": q.qsize()})
 


### PR DESCRIPTION
Updates api endpoints to allow + and %20 to be both encoded to ``` ``` and allow encoded slashes to work. Slash configuration is due to a bug in WSGI.

Keeps legacy api endpoints, though moves the hash into a query parameter and switches the matching on the endpoints to string instead of path.

Fix #18 