### PR TITLE
Multistage Dockerfile to download model

### DIFF
--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -1,3 +1,10 @@
+FROM python:3.7-slim as download-model
+RUN pip install --no-cache-dir numpy requests
+COPY ./dnnlib /app/dnnlib
+COPY ./fetchModel.py /app/fetchModel.py
+WORKDIR /app
+RUN python3.7 fetchModel.py
+
 FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends software-properties-common
@@ -11,7 +18,6 @@ RUN pip install -r /app/requirements.txt
 COPY ./dnnlib /app/dnnlib
 COPY ./fetchModel.py /app/fetchModel.py
 WORKDIR /app
-RUN python3.7 fetchModel.py
 COPY . /app
-
+COPY --from=download-model /app/cache /app/cache
 CMD ["python3.7", "checkface.py"]

--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.7-slim as download-model
-RUN pip install --no-cache-dir numpy requests
+RUN pip install --no-cache-dir numpy==1.16.3 requests==2.21.0
 COPY ./dnnlib /app/dnnlib
 COPY ./fetchModel.py /app/fetchModel.py
 WORKDIR /app


### PR DESCRIPTION
Whenever any changes are made early on in the dockerfile build, such as updating the requirements.txt, the model has to be downloaded again.

This moves the fetchModel to a separate build stage so that it can be cached.