### PR TITLE
Revert "Bump pyxdg from 0.25 to 0.26 in /src/server"

### DIFF
--- a/src/server/requirements.txt
+++ b/src/server/requirements.txt
@@ -36,7 +36,7 @@ protobuf==3.10.0
 pycrypto==2.6.1
 pygobject==3.26.1
 python-apt==1.6.4
-pyxdg==0.26
+pyxdg==0.25
 requests==2.22.0
 scipy==1.3.3
 SecretStorage==2.3.1


### PR DESCRIPTION
Reverts check-face/checkface#40

Doesn't build:

```
.
.
.
#13 47.34 Successfully built prometheus-client pycparser PyYAML
#13 47.40 Installing collected packages: pycparser, cffi, Click, cryptography, MarkupSafe, Jinja2, itsdangerous, Flask, idna, mock, pep8, prometheus-client, pyOpenSSL, PyYAML, pymongo, pyxdg, tensorflow-gpu
#13 47.53   Found existing installation: cryptography 2.1.4
#13 47.53     Uninstalling cryptography-2.1.4:
#13 47.55       Successfully uninstalled cryptography-2.1.4
#13 47.70   Found existing installation: idna 2.6
#13 47.70     Uninstalling idna-2.6:
#13 47.71       Successfully uninstalled idna-2.6
#13 47.92   Found existing installation: pyxdg 0.25
#13 48.20 ERROR: Cannot uninstall 'pyxdg'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
#13 48.33 WARNING: You are using pip version 19.3.1; however, version 20.0.2 is available.
#13 48.33 You should consider upgrading via the 'pip install --upgrade pip' command.
------
failed to solve with frontend dockerfile.v0: failed to build LLB: executor failed running [/bin/bash -c pip install --no-cache-dir -r /app/requirements.txt]: runc did not terminate sucessfully
```